### PR TITLE
Custom storage support

### DIFF
--- a/filebrowser/functions.py
+++ b/filebrowser/functions.py
@@ -9,7 +9,6 @@ from urlparse import urlparse
 from django.utils.translation import ugettext as _
 from django.utils.safestring import mark_safe
 from django.core.files import File
-from django.core.files.storage import default_storage
 from django.utils.encoding import smart_str
 
 # filebrowser imports
@@ -238,7 +237,7 @@ def handle_file_upload(path, file):
     """
     
     file_path = os.path.join(path, file.name)
-    uploadedfile = default_storage.save(file_path, file)
+    uploadedfile = FILEBROWSER_STORAGE.save(file_path, file)
     return uploadedfile
 
 

--- a/filebrowser/settings.py
+++ b/filebrowser/settings.py
@@ -16,6 +16,20 @@ except ImportError:
     DEFAULT_URL_TINYMCE = settings.ADMIN_MEDIA_PREFIX + "tinymce/jscripts/tiny_mce/"
     DEFAULT_PATH_TINYMCE = os.path.join(settings.MEDIA_ROOT, 'admin/tinymce/jscripts/tiny_mce/')
 
+# storage settings
+if hasattr(settings, 'FILEBROWSER_STORAGE_CLASS'):
+    from django.core.files.storage import get_storage_class
+    from django.utils.functional import LazyObject
+
+    class FilebrowserStorageClass(LazyObject):
+        def _setup(self):
+            self._wrapped = get_storage_class(import_path=settings.FILEBROWSER_STORAGE_CLASS)()
+
+    FILEBROWSER_STORAGE = FilebrowserStorageClass()
+else:
+    from django.core.files.storage import default_storage
+    FILEBROWSER_STORAGE = default_storage
+
 # Set to True in order to see the FileObject when Browsing.
 DEBUG = getattr(settings, "FILEBROWSER_DEBUG", False)
 


### PR DESCRIPTION
One small feature for the app. Allows to set a custom storage class for the filebrowser like
FILEBROWSER_STORAGE_CLASS = 'django.core.files.storage.FileSystemStorage'
