### PR TITLE
allow unicode filenames

### DIFF
--- a/filebrowser/functions.py
+++ b/filebrowser/functions.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 from django.utils.safestring import mark_safe
 from django.core.files import File
 from django.core.files.storage import default_storage
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_unicode
 
 # filebrowser imports
 from filebrowser.settings import *
@@ -75,7 +75,7 @@ def get_version_path(value, version_prefix):
     Returns a path relative to MEDIA_ROOT.
     """
     
-    if os.path.isfile(smart_str(os.path.join(fb_settings.MEDIA_ROOT, value))):
+    if os.path.isfile(smart_unicode(os.path.join(fb_settings.MEDIA_ROOT, value))):
         path, filename = os.path.split(value)
         filename, ext = os.path.splitext(filename)
         
@@ -87,7 +87,7 @@ def get_version_path(value, version_prefix):
             # so we strip the suffix (aka. version_perfix)
             new_filename = filename.replace("_" + tmp[len(tmp)-1], "")
             # check if the version exists when we use the new_filename
-            if os.path.isfile(smart_str(os.path.join(fb_settings.MEDIA_ROOT, path, new_filename + "_" + version_prefix + ext))):
+            if os.path.isfile(smart_unicode(os.path.join(MEDIA_ROOT, path, new_filename + "_" + version_prefix + ext))):
                 # our "original" filename seem to be filename_<version> construct
                 # so we replace it with the new_filename
                 filename = new_filename
@@ -161,7 +161,7 @@ def get_file(path, filename):
     Get File.
     """
     
-    converted_path = smart_str(os.path.join(fb_settings.MEDIA_ROOT, fb_settings.DIRECTORY, path, filename))
+    converted_path = smart_unicode(os.path.join(MEDIA_ROOT, DIRECTORY, path, filename))
     
     if not os.path.isfile(converted_path) and not os.path.isdir(converted_path):
         return None
@@ -288,9 +288,9 @@ def version_generator(value, version_prefix, force=None):
     ImageFile.MAXBLOCK = IMAGE_MAXBLOCK # default is 64k
     
     try:
-        im = Image.open(smart_str(os.path.join(fb_settings.MEDIA_ROOT, value)))
+        im = Image.open(smart_unicode(os.path.join(fb_settings.MEDIA_ROOT, value)))
         version_path = get_version_path(value, version_prefix)
-        absolute_version_path = smart_str(os.path.join(fb_settings.MEDIA_ROOT, version_path))
+        absolute_version_path = smart_unicode(os.path.join(fb_settings.MEDIA_ROOT, version_path))
         version_dir = os.path.split(absolute_version_path)[0]
         if not os.path.isdir(version_dir):
             os.makedirs(version_dir)

--- a/filebrowser/views.py
+++ b/filebrowser/views.py
@@ -17,7 +17,7 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured
 from django.dispatch import Signal
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_unicode
 
 try:
     # django SVN
@@ -272,7 +272,7 @@ def _check_file(request):
         for k,v in request.POST.items():
             if k != "folder":
                 v = convert_filename(v)
-                if os.path.isfile(smart_str(_check_access(request, folder, v))):
+                if os.path.isfile(smart_unicode(_check_access(request, folder, v))):
                     fileArray[k] = v
     
     return HttpResponse(simplejson.dumps(fileArray))
@@ -306,9 +306,9 @@ def _upload_file(request):
             uploadedfile = handle_file_upload(abs_path, filedata)
             # MOVE UPLOADED FILE
             # if file already exists
-            if os.path.isfile(smart_str(os.path.join(fb_settings.MEDIA_ROOT, fb_settings.DIRECTORY, folder, filedata.name))):
-                old_file = smart_str(os.path.join(abs_path, filedata.name))
-                new_file = smart_str(os.path.join(abs_path, uploadedfile))
+            if os.path.isfile(smart_unicode(os.path.join(fb_settings.MEDIA_ROOT, fb_settings.DIRECTORY, folder, filedata.name))):
+                old_file = smart_unicode(os.path.join(abs_path, filedata.name))
+                new_file = smart_unicode(os.path.join(abs_path, uploadedfile))
                 file_move_safe(new_file, old_file)
             # POST UPLOAD SIGNAL
             filebrowser_post_upload.send(sender=request, path=request.POST.get('folder'), file=FileObject(smart_str(os.path.join(fb_settings.DIRECTORY, folder, filedata.name))))
@@ -348,7 +348,7 @@ def delete(request):
                 filebrowser_pre_delete.send(sender=request, path=path, filename=filename)
 
                 # DELETE FILE
-                os.unlink(smart_str(_check_access(request, path, filename)))
+                os.unlink(smart_unicode(_check_access(request, path, filename)))
                 # DELETE IMAGE VERSIONS/THUMBNAILS
                 for version in VERSIONS:
                     try:


### PR DESCRIPTION
Convert smart_str to smart_unicode to allow filenames with unicode characters.

Base on upstream (grapelli) changeset https://github.com/sehmaschine/django-filebrowser/commit/582836c28d1d70558c8e394a81808c754b5cc851
Tested only on Windows with Czech filenames.
