### PR TITLE
Fix url imports for Django 1.6+

### DIFF
--- a/filebrowser/urls.py
+++ b/filebrowser/urls.py
@@ -1,7 +1,10 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import url, patterns
+except ImportError:
+    from django.conf.urls.defaults import url, patterns
 
 urlpatterns = patterns('',
-    
+
     # filebrowser urls
     url(r'^browse/$', 'filebrowser.views.browse', name="fb_browse"),
     url(r'^mkdir/', 'filebrowser.views.mkdir', name="fb_mkdir"),
@@ -9,8 +12,8 @@ urlpatterns = patterns('',
     url(r'^rename/$', 'filebrowser.views.rename', name="fb_rename"),
     url(r'^delete/$', 'filebrowser.views.delete', name="fb_delete"),
     url(r'^versions/$', 'filebrowser.views.versions', name="fb_versions"),
-    
+
     url(r'^check_file/$', 'filebrowser.views._check_file', name="fb_check"),
     url(r'^upload_file/$', 'filebrowser.views._upload_file', name="fb_do_upload"),
-    
+
 )


### PR DESCRIPTION
Attempt to import url/patterns from the new django.conf.urls location before falling on the old django.conf.urls.defaults location.
