### PR TITLE
Conditionally imports native json vs simplejson based on python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# django-filebrowser-no-grappelli
+django-filebrowser for default Django admin site.  Based on https://github.com/sehmaschine/django-filebrowser v3.1 (before it was in git)  Consider using https://github.com/smacker/django-filebrowser-no-grappelli which is based on a newer version
+
+This fork works with Django 1.8 by conditionally importing simplejson based on the pythong version.

--- a/filebrowser/views.py
+++ b/filebrowser/views.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 # general imports
-import os, re
+import os, re, sys
 from time import gmtime, strftime
 
 # django imports
@@ -261,7 +261,11 @@ def _check_file(request):
     Check if file already exists on the server.
     """
     
-    from django.utils import simplejson
+    if sys.version_info < (2, 6):
+        from django.utils import simplejson
+    else:
+        import json as simplejson
+
     
     folder = request.POST.get('folder')
     fb_uploadurl_re = re.compile(r'^.*(%s)' % reverse("fb_upload"))


### PR DESCRIPTION
This only needed a simple fix to make it compatible with up to Django 1.8. By conditionally importing native json versus simplejson from django.contribs, this can work with all up to date versions of Django.
